### PR TITLE
fix example module path

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
   // Example for how to create a new alert with this module
   // Usage: USER=something@gmail.com PASS=password node example.js
 
-  var ga = require('index');
+  var ga = require('./index.js');
   var alerts = new ga({ user: process.env.USER, pass: process.env.PASS });
 
   alerts


### PR DESCRIPTION
`example.js` as written throws an error because it's looking for a module called `index` instead of getting a local path to `index.js`.

Renaming it as a path fixes this.

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'index'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/mike/wrk/test/node-google-alerts/example.js:5:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```
